### PR TITLE
add glass digital sub-path

### DIFF
--- a/pmd/.htaccess
+++ b/pmd/.htaccess
@@ -6,25 +6,30 @@ RewriteCond %{HTTP_ACCEPT} !application/rdf\+xml.*(text/html|application/xhtml\+
 RewriteCond %{HTTP_ACCEPT} text/html [OR]
 RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml 
 RewriteRule ^co(.*)$ https://materialdigital.github.io/core-ontology/index-en.html [R=303,L]
+RewriteRule ^glass-ontology(.*)$ https://materialdigital.github.io/glasdigital-ontology/index-en.html [R=303,L]
 
 # Rewrite rule to serve JSON-LD content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/ld\+json
 RewriteRule ^co(.*)$ https://materialdigital.github.io/core-ontology/ontology.jsonld [R=303,L]
+RewriteRule ^glass-ontology(.*)$ https://materialdigital.github.io/glasdigital-ontology/ontology.jsonld [R=303,L]
 
 # Rewrite rule to serve RDF/XML content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} \*/\* [OR]
 RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
 RewriteRule ^co(.*)$ https://materialdigital.github.io/core-ontology/ontology.rdf [R=303,L]
+RewriteRule ^glass-ontology(.*)$ https://materialdigital.github.io/glasdigital-ontology/ontology.rdf [R=303,L]
 
 # Rewrite rule to serve N-Triples content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^co(.*)$ https://materialdigital.github.io/core-ontology/ontology.nt [R=303,L]
+RewriteRule ^glass-ontology(.*)$ https://materialdigital.github.io/glasdigital-ontology/ontology.nt [R=303,L]
 
 # Rewrite rule to serve TTL content from the vocabulary URI if requested
 RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
 RewriteCond %{HTTP_ACCEPT} text/\* [OR]
 RewriteCond %{HTTP_ACCEPT} \*/turtle
 RewriteRule ^co(.*)$ https://materialdigital.github.io/core-ontology/ontology.ttl [R=303,L]
+RewriteRule ^glass-ontology(.*)$ https://materialdigital.github.io/glasdigital-ontology/ontology.ttl [R=303,L]
 
 #RewriteCond %{HTTP_ACCEPT} .+
 #RewriteRule ^$ https://materialdigital.github.io/core-ontology/406.html [R=406,L]

--- a/pmd/README.md
+++ b/pmd/README.md
@@ -2,7 +2,9 @@
 This [W3ID](https://w3id.org) provides a persistent URI namespace for the platform material digital vocabularies.
 
 ## Uses
-This namespace represents a general ontology for the platform material digital.
+This namespace represents a general ontology namespace for the platform material digital while subpaths point to specific vocabularies, currently:
+- `co`: PMD Core Ontology (PMDco)
+- `glass-ontology`: Glass Digital Ontology (PMDgo)
 
 ## Contact
 Current maintainers are:


### PR DESCRIPTION
we choose 'glass-ontology' over 'go' because the latter is very ambiguous

Refs: https://github.com/materialdigital/glasdigital-ontology/issues/6